### PR TITLE
Dropbox same attachment filename issue fixed

### DIFF
--- a/components/nsDropbox.js
+++ b/components/nsDropbox.js
@@ -568,6 +568,7 @@ nsDropboxFileUploader.prototype = {
         this.log.info("success putting file " + aResponseText);
         let putInfo = JSON.parse(aResponseText);
         this.dropbox._uploadInfo[this.file.path] = putInfo;
+	this.file.leafName = putInfo['path'].substr(1);
         this._getShareUrl(this.file, this.callback);
       }.bind(this),
       function(aException, aResponseText, aRequest) {


### PR DESCRIPTION
See commit message - "Uploaded file name returned by Dropbox process is assigned to leafName, automatically correct filename is passed to _getShareUrl function. As a result proper URL is returned."

If in your opinion assigning to this variable is a mistake (or just bad practice) just let me know and I will replace it with another code, where special variable is created for this purpose.

There is still wrong file name inserted into mail body, but it seems to be more problematic to fix.

Tested on Xubuntu 12.04.1 and Thunderbird 16.0.2
